### PR TITLE
Connected a react hook to help render the nodes

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 PG_URI=postgres://tycqpgyk:dm4WbqCz-8d02icGprf3TeAl6rIM9Mpk@drona.db.elephantsql.com/tycqpgyk
-GOOGLE_CLIENT_ID="http://5354437150-3nrov3m1foon5jpb4t4let2uu9anf4ep.apps.googleusercontent.com/"
+GOOGLE_CLIENT_ID=5354437150-3nrov3m1foon5jpb4t4let2uu9anf4ep.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=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
 GITHUB_CLIENT_ID=44b5b3fbf70f9f98a42d
 GITHUB_CLIENT_SECRET=f824417c1da5b9d2e50a59394f7ffa2c7044106e

--- a/src/app/QueryContainer.tsx
+++ b/src/app/QueryContainer.tsx
@@ -5,14 +5,14 @@ import "tailwindcss/tailwind.css";
 import QueryGenerator from "./QueryGenerator";
 import QueryResult from "./QueryResult";
 
-export default function QueryContainer({ endpoint }: any) { // TODO: type
+export default function QueryContainer({ endpoint, clickField }: any) { // TODO: type
   const [data, setData] = useState("");
   const childToParent = (childData: any) => {
     setData(childData);
   };
   return (
     <>
-      <QueryGenerator childToParent={childToParent} />
+      <QueryGenerator childToParent={childToParent} clickField={clickField}/>
       <QueryResult data={data} endpoint={endpoint} />
     </>
   );

--- a/src/app/QueryGenerator.tsx
+++ b/src/app/QueryGenerator.tsx
@@ -1,15 +1,38 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useLayoutEffect } from "react";
 import "tailwindcss/tailwind.css";
 import { jsonToGraphQLQuery } from "json-to-graphql-query";
 
-export default function QueryGenerator({ childToParent }: any) {
+export default function QueryGenerator({ childToParent, clickField }: any ) {
   const [result, setResult] = useState("");
   const [schemaVal, setSchemaVal] = useState("");
   const [queryAsObj, setQueryAsObj] = useState({ query: {} });
   const [queryAsString, setQueryAsString] = useState("query: { \n \n }");
-
+  
+  const updateQueryAsObj = (fieldName: string, typeName: string) => {
+    //make a deep copy of queryAsObj
+    const tempObj = JSON.parse(JSON.stringify(queryAsObj));
+    //@ts-ignore
+    if (!tempObj.query[typeName]) {
+      tempObj.query[typeName] = {};
+    }
+    tempObj.query[typeName][fieldName] = true;
+    //update object in state
+    setQueryAsObj(tempObj);
+    //update string in state
+    setQueryAsString(jsonToGraphQLQuery(tempObj, { pretty: true }));
+    
+  };
   // console.log("CHILD TO PARENT", childToParent);
-  useEffect(() => childToParent(queryAsString));
+  useEffect(() => {
+    childToParent(queryAsString);
+    console.log("useEffect ran");
+    
+  });
+
+  // useEffect(() => {
+  useEffect(() => {
+    if(clickField.field && clickField.type) updateQueryAsObj(clickField.field.toLowerCase(), clickField.type.toLowerCase())
+  }, [clickField])
 
   console.log("this is query as a string:", queryAsString);
   console.log("this is query as a object:", queryAsObj);
@@ -26,20 +49,7 @@ export default function QueryGenerator({ childToParent }: any) {
   // console.log('THIS IS THE JSON TO GRAPHQLQUERY', jsonToGraphQLQuery(queryAsObj, { pretty: true }))
 
   // this function will be the onClick for each button, it should check if the type of the field that was clicked is already on queryStructure, if so, it will add a new element to the array value of the corresponding type, if not, it will add the type as a property with a value of an array with only the clicked field as an element. after that, it will call stringifyQuery and re-render the value of the textarea.
-  const updateQueryAsObj = (fieldName: string, typeName: string) => {
-    //make a deep copy of queryAsObj
-    const tempObj = JSON.parse(JSON.stringify(queryAsObj));
-    //@ts-ignore
-    if (!tempObj.query[typeName]) {
-      tempObj.query[typeName] = {};
-    }
-    tempObj.query[typeName][fieldName] = true;
-    //update object in state
-    setQueryAsObj(tempObj);
-    //update string in state
-    setQueryAsString(jsonToGraphQLQuery(tempObj, { pretty: true }));
-    
-  };
+
 
   return (
     <div className="flex items-center justify-center">

--- a/src/app/components/DisplayData.tsx
+++ b/src/app/components/DisplayData.tsx
@@ -49,14 +49,20 @@ let yindex = 0;
 const initialEdges: any[] = []; // TODO: type
 console.log('this is our nodes', initialNodes)
 
-const onNodeClick = (event: any, node: any) => console.log('click node', node);
+
 
 
 export function DisplayData(props: any) { // TODO: type
 
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
-
+  
+  const onNodeClick = (event: any, node: any) => {
+    console.log('click node', node);
+      
+    props.setClickField({type: node.parentNode, field: node.data.label})
+  }
+  
   //background variant
   const [ variant, setVariant ] = useState('dots');
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import QueryContainer from "./QueryContainer";
 export default function Home({ session }: any) {
   // data fetching: https://youtu.be/gSSsZReIFRk?t=293
   const [data, setData] = useState({});
+  const [clickField, setClickField] = useState({});
   const childToParent = (childData: any) => {
     //TODO: type
     setData(childData);
@@ -21,9 +22,9 @@ export default function Home({ session }: any) {
     <>
       <SessionProvider session={session}>
         <EndpointForm childToParent={childToParent} />
-        <DisplayData data={data} />
+        <DisplayData data={data} setClickField={setClickField} />
       </SessionProvider>
-      <QueryContainer endpoint={data.endpoint} />
+      <QueryContainer endpoint={data.endpoint} clickField={clickField} />
     </>
   );
 }

--- a/src/utils/schemaConnect.ts
+++ b/src/utils/schemaConnect.ts
@@ -63,3 +63,191 @@ export async function schemaConnect(apiEndpoint: string) {
     })
    return schemaData;
 }
+
+/*
+
+query = {
+  __schema{
+    queryType{
+      name
+      fields {
+        name
+        description
+        type{
+          name
+          fields{
+            name
+          }
+        }
+      }
+    }
+  }
+}
+
+returns 
+
+{
+  "data": {
+    "__schema": {
+      "queryType": {
+        "name": "Query",
+        "fields": [
+          {
+            "name": "continent",****
+            "description": null,
+            "type": {
+              "name": "Continent",
+              "fields": [
+                {
+                  "name": "code",****
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "countries",****
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "name",****
+                  "__typename": "__Field"
+                }
+              ],
+              "__typename": "__Type"
+            },
+            "__typename": "__Field"
+          },
+          {
+            "name": "continents",****
+            "description": null,
+            "type": {
+              "name": null,
+              "fields": null,
+              "__typename": "__Type"
+            },
+            "__typename": "__Field"
+          },
+          {
+            "name": "countries",
+            "description": null,
+            "type": {
+              "name": null,
+              "fields": null,
+              "__typename": "__Type"
+            },
+            "__typename": "__Field"
+          },
+          {
+            "name": "country",
+            "description": null,
+            "type": {
+              "name": "Country",
+              "fields": [
+                {
+                  "name": "awsRegion",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "capital",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "code",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "continent",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "currencies",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "currency",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "emoji",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "emojiU",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "languages",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "name",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "native",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "phone",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "phones",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "states",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "subdivisions",
+                  "__typename": "__Field"
+                }
+              ],
+              "__typename": "__Type"
+            },
+            "__typename": "__Field"
+          },
+          {
+            "name": "language",
+            "description": null,
+            "type": {
+              "name": "Language",
+              "fields": [
+                {
+                  "name": "code",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "name",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "native",
+                  "__typename": "__Field"
+                },
+                {
+                  "name": "rtl",
+                  "__typename": "__Field"
+                }
+              ],
+              "__typename": "__Type"
+            },
+            "__typename": "__Field"
+          },
+          {
+            "name": "languages",
+            "description": null,
+            "type": {
+              "name": null,
+              "fields": null,
+              "__typename": "__Type"
+            },
+            "__typename": "__Field"
+          }
+        ],
+        "__typename": "__Type"
+      },
+      "__typename": "__Schema"
+    }
+  }
+}
+*/


### PR DESCRIPTION
## Overview

**Issue Type**

- [x] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
Added useEffect react hook in multiple places within the `queryGenerator` component to help update the state of each child node when clicked on. This PR should also allow us to view the data parsed correctly in the node object after the user clicks on it. All remaining functionality from previous builds should operate the same. The main piece this PR is doing is parsing the data correctly in the console as well as the two useEffect hooks you see within `queryGenerator`


**Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix**

1. Run a valid query and click on one of the child nodes
2. You should see the node object logged correctly with the correct data. The name, and the parentNode fields should render data.




