### PR TITLE
Redesign the sign in and sign out buttons 

### DIFF
--- a/src/app/components/EndpointForm.tsx
+++ b/src/app/components/EndpointForm.tsx
@@ -22,14 +22,11 @@ export function EndpointForm({ childToParent }: any) {
         {/* <button onClick={() => signOut()} >Sign Out</button> */}
       </div>
     ) : (
-      <div className="flex items-center space-x-1">
-        {/* <button onClick={() => signIn()}>Sign In</button> */}
+      <div>
+        <h1 className="mr-1">Authentication not found</h1>{" "}
       </div>
     );
   }
-
-
-  
   return (
     <>
       <form action={handleSubmit} className="m-1 flex items-center">

--- a/src/app/components/EndpointForm.tsx
+++ b/src/app/components/EndpointForm.tsx
@@ -1,4 +1,5 @@
 import { getSchema } from "@/utils/getSchema";
+import { sign } from "crypto";
 import { useSession, signIn, signOut } from "next-auth/react";
 
 export function EndpointForm({ childToParent }: any) {
@@ -16,15 +17,19 @@ export function EndpointForm({ childToParent }: any) {
 
   function checkIfLoggedIn() {
     return status === "authenticated" ? (
-      <>
-        <h1>Welcome {session.user!.email}</h1>{" "}
-        <button onClick={() => signOut()}>Sign Out</button>
-      </>
+      <div className="flex items-center space-x-1">
+        <h1 className="mr-1">Welcome {session.user!.email}</h1>{" "}
+        <button onClick={() => signOut()} >Sign Out</button>
+      </div>
     ) : (
-      <button onClick={() => signIn()}>Sign In</button>
+      <div className="flex items-center space-x-1">
+        <button onClick={() => signIn()}>Sign In</button>
+      </div>
     );
   }
 
+
+  
   return (
     <>
       <form action={handleSubmit} className="flex items-center">
@@ -55,7 +60,7 @@ export function EndpointForm({ childToParent }: any) {
         </div>
         <button
           type="submit"
-          className="p-2.5 ml-2 text-sm font-medium text-white bg-blue-700 rounded-lg border border-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+          className="p-2.5 ml-1 mr-1 text-sm font-medium text-white bg-blue-700 rounded-lg border border-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
         >
           <svg
             className="w-5 h-5"
@@ -72,6 +77,7 @@ export function EndpointForm({ childToParent }: any) {
             ></path>
           </svg>
         </button>
+
       </form>
 
       {checkIfLoggedIn()}

--- a/src/app/components/EndpointForm.tsx
+++ b/src/app/components/EndpointForm.tsx
@@ -19,11 +19,11 @@ export function EndpointForm({ childToParent }: any) {
     return status === "authenticated" ? (
       <div className="flex items-center space-x-1">
         <h1 className="mr-1">Welcome {session.user!.email}</h1>{" "}
-        <button onClick={() => signOut()} >Sign Out</button>
+        {/* <button onClick={() => signOut()} >Sign Out</button> */}
       </div>
     ) : (
       <div className="flex items-center space-x-1">
-        <button onClick={() => signIn()}>Sign In</button>
+        {/* <button onClick={() => signIn()}>Sign In</button> */}
       </div>
     );
   }
@@ -32,7 +32,7 @@ export function EndpointForm({ childToParent }: any) {
   
   return (
     <>
-      <form action={handleSubmit} className="flex items-center">
+      <form action={handleSubmit} className="m-1 flex items-center">
         <div className="relative w-full">
           <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
             <svg
@@ -77,6 +77,16 @@ export function EndpointForm({ childToParent }: any) {
             ></path>
           </svg>
         </button>
+        <div className="flex items-center space-x-1">
+    {/* Sign In button */}
+    <button onClick={() => signIn()} className=" w-32 bg-blue-500 text-white px-3 py-2 rounded-lg">
+      Sign In
+    </button>
+    {/* Sign Out button */}
+    <button onClick={() => signOut()} className=" w-32 bg-red-500 text-white px-3 py-2 rounded-lg">
+      Sign Out
+    </button>
+    </div>
 
       </form>
 


### PR DESCRIPTION
## Overview

**Issue Type**

- [ ] Bug
- [x] Feature
- [ ] Tech Debt

**Description**
Changed the position and the styling of the sign in button and sign out button. You should now see them in the top right corner next to the submit button.


**Steps to Validate Feature 

1. Go to http://localhost:3000/
2. You should see the sign in button and sign out button with a new design that runs the logic of OAuth.

**Previous behavior**
The sign in button was just rendered in the main body of the page and didn't look appealing for MVP. The same situation for sign out was happening.

**Expected behavior**
You should see the two buttons next to the submit button.

