### PR TITLE
Dynamically show sign in and sign out with profile photo

### DIFF
--- a/src/app/components/EndpointForm.tsx
+++ b/src/app/components/EndpointForm.tsx
@@ -3,6 +3,7 @@ import { sign } from "crypto";
 import { useSession, signIn, signOut } from "next-auth/react";
 import { Menu, Transition } from '@headlessui/react';
 import { Fragment, useEffect, useState } from "react";
+import Image from "next/image";
 
 
 
@@ -51,16 +52,20 @@ const onSignOut = () => {
   const { data: session, status } = useSession();
 
   function checkIfLoggedIn() {
-    return status === "authenticated" ? (
-      <div className="p-5 flex items-center space-x-1 dark:bg-slate-800 dark:text-white">
-        {/* <h1 className="mr-1">Welcome {session.user!.email}</h1>{" "} */}
-        {/* <button onClick={() => signOut()} >Sign Out</button> */}
-      </div>
-    ) : (
-      <div>
-      </div>
-    );
+    return status === "authenticated";
   }
+
+  // function checkIfLoggedIn() {
+  //   return status === "authenticated" ? (
+  //     <div className="p-5 flex items-center space-x-1 dark:bg-slate-800 dark:text-white">
+  //       {/* <h1 className="mr-1">Welcome {session.user!.email}</h1>{" "} */}
+  //       {/* <button onClick={() => signOut()} >Sign Out</button> */}
+  //     </div>
+  //   ) : (
+  //     <div>
+  //     </div>
+  //   );
+  // }
   return (
     <>
       {/* <form action={handleSubmit} className="pt-5 pr-4 pl-4 flex items-center dark:bg-slate-800"> */}
@@ -111,14 +116,14 @@ const onSignOut = () => {
           </svg>
         </button>
         {/* User Account Dropdown */}
-        <div className="flex items-center space-x-1">
+        <div className="flex items-center space-x-1.5">
           <Menu as='div' className='relative inline-block text-left'>
             <div>
               {/* Account Button */} 
               {/* <Menu.Button className='inline-flex w-full justify-center gap-x-1.5 border border-blue-500 rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm ring-1 ring-inset hover:bg-gray-200 dark:bg-slate-500 dark:border-white dark:hover:bg-slate-300'></Menu.Button>      */}
               <Menu.Button className='inline-flex w-full justify-center gap-x-1.5 border border-blue-500 rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm ring-1 ring-inset hover:bg-gray-200 dark:bg-slate-500 dark:border-white dark:hover:bg-slate-300'>
               {isLoggedIn ? (
-                    <img src={image} alt="" className="border-blue-500 rounded-sm w-6 h-6"
+                    <img src={image} alt="" className="inline-flex w-full justify-center gap-x-1.5 border-blue-500 rounded-sm w-6 h-6"
                     />
                   ) : (
                     <svg
@@ -161,7 +166,8 @@ const onSignOut = () => {
               leaveFrom='transform opacity-100 scale-100'
               leaveTo='transform opacity-0 scale-95'
             >
-             <Menu.Items className="absolute right-0 mt-2 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+              {/* //mt-2 */}
+             <Menu.Items className="absolute right-0 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
               <div className="px-1 py-1">
                 <Menu.Item>
                   {isLoggedIn ? (

--- a/src/app/components/EndpointForm.tsx
+++ b/src/app/components/EndpointForm.tsx
@@ -2,10 +2,30 @@ import { getSchema } from "@/utils/getSchema";
 import { sign } from "crypto";
 import { useSession, signIn, signOut } from "next-auth/react";
 import { Menu, Transition } from '@headlessui/react';
-import { Fragment } from "react";
+import { Fragment, useEffect, useState } from "react";
+
+
 
 export function EndpointForm({ childToParent }: any) {
+  const [ isLoggedIn, setIsLoggedIn ] = useState(false);
+  const { data: instance } = useSession();
+  const image: any = instance?.user?.image;
+
+  useEffect(() => {
+    console.log('this is the instance, aka session object ---->', instance)
+ 
+    setIsLoggedIn(!!instance);
+  }, [instance])
   //TODO: type
+  const onSignIn = () => {
+    signIn();
+    }
+
+const onSignOut = () => {
+  signOut();
+  setIsLoggedIn(false);
+  
+}
 
   const toggleTheme = () => {
     // query for HTML element
@@ -33,17 +53,17 @@ export function EndpointForm({ childToParent }: any) {
   function checkIfLoggedIn() {
     return status === "authenticated" ? (
       <div className="p-5 flex items-center space-x-1 dark:bg-slate-800 dark:text-white">
-        <h1 className="mr-1">Welcome {session.user!.email}</h1>{" "}
+        {/* <h1 className="mr-1">Welcome {session.user!.email}</h1>{" "} */}
         {/* <button onClick={() => signOut()} >Sign Out</button> */}
       </div>
     ) : (
       <div>
-        <h1 className="p-5 mr-1 dark:bg-slate-800 dark:text-white">Authentication not found</h1>{" "}
       </div>
     );
   }
   return (
     <>
+      {/* <form action={handleSubmit} className="pt-5 pr-4 pl-4 flex items-center dark:bg-slate-800"> */}
       <form action={handleSubmit} className="pt-5 pr-4 pl-4 flex items-center dark:bg-slate-800">
         <div className="relative w-full">
           <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
@@ -94,9 +114,14 @@ export function EndpointForm({ childToParent }: any) {
         <div className="flex items-center space-x-1">
           <Menu as='div' className='relative inline-block text-left'>
             <div>
-              {/* Account Button */}      
+              {/* Account Button */} 
+              {/* <Menu.Button className='inline-flex w-full justify-center gap-x-1.5 border border-blue-500 rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm ring-1 ring-inset hover:bg-gray-200 dark:bg-slate-500 dark:border-white dark:hover:bg-slate-300'></Menu.Button>      */}
               <Menu.Button className='inline-flex w-full justify-center gap-x-1.5 border border-blue-500 rounded-md px-3 py-2 text-sm font-semibold text-white shadow-sm ring-1 ring-inset hover:bg-gray-200 dark:bg-slate-500 dark:border-white dark:hover:bg-slate-300'>
-                <svg
+              {isLoggedIn ? (
+                    <img src={image} alt="" className="border-blue-500 rounded-sm w-6 h-6"
+                    />
+                  ) : (
+                    <svg
                   className="w-6 h-6 flex items-center text-blue-500 dark:text-white"
                   fill="none"
                   stroke="currentColor"
@@ -110,6 +135,21 @@ export function EndpointForm({ childToParent }: any) {
                     d="M12.075,10.812c1.358-0.853,2.242-2.507,2.242-4.037c0-2.181-1.795-4.618-4.198-4.618S5.921,4.594,5.921,6.775c0,1.53,0.884,3.185,2.242,4.037c-3.222,0.865-5.6,3.807-5.6,7.298c0,0.23,0.189,0.42,0.42,0.42h14.273c0.23,0,0.42-0.189,0.42-0.42C17.676,14.619,15.297,11.677,12.075,10.812 M6.761,6.775c0-2.162,1.773-3.778,3.358-3.778s3.359,1.616,3.359,3.778c0,2.162-1.774,3.778-3.359,3.778S6.761,8.937,6.761,6.775 M3.415,17.69c0.218-3.51,3.142-6.297,6.704-6.297c3.562,0,6.486,2.787,6.705,6.297H3.415z"
                   ></path>          
                 </svg>
+                  )}
+                {/* <svg
+                  className="w-6 h-6 flex items-center text-blue-500 dark:text-white"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                  >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="1"
+                    d="M12.075,10.812c1.358-0.853,2.242-2.507,2.242-4.037c0-2.181-1.795-4.618-4.198-4.618S5.921,4.594,5.921,6.775c0,1.53,0.884,3.185,2.242,4.037c-3.222,0.865-5.6,3.807-5.6,7.298c0,0.23,0.189,0.42,0.42,0.42h14.273c0.23,0,0.42-0.189,0.42-0.42C17.676,14.619,15.297,11.677,12.075,10.812 M6.761,6.775c0-2.162,1.773-3.778,3.358-3.778s3.359,1.616,3.359,3.778c0,2.162-1.774,3.778-3.359,3.778S6.761,8.937,6.761,6.775 M3.415,17.69c0.218-3.51,3.142-6.297,6.704-6.297c3.562,0,6.486,2.787,6.705,6.297H3.415z"
+                  ></path>          
+                </svg> */}
               </Menu.Button>
             </div>
             <Transition
@@ -121,20 +161,19 @@ export function EndpointForm({ childToParent }: any) {
               leaveFrom='transform opacity-100 scale-100'
               leaveTo='transform opacity-0 scale-95'
             >
-              <Menu.Items className='absolute right-0 mt-2 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none'>
-                <div className="px-1 py-1">
-                  <Menu.Item>
-                    <button type='submit' onClick={signIn} className="inline-flex r-2 w-56 hover:bg-slate-300"> {/* TODO: look into this error */}
-                      Sign In
-                    </button>
-                  </Menu.Item>
-                  <br></br>
-                  <Menu.Item>
-                    <button onClick={signOut} className="inline-flex w-56 hover:bg-slate-300">
+             <Menu.Items className="absolute right-0 mt-2 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+              <div className="px-1 py-1">
+                <Menu.Item>
+                  {isLoggedIn ? (
+                    <button onClick={onSignOut} className="inline-flex w-56 hover:bg-slate-300">
                       Sign Out
                     </button>
-                  </Menu.Item>
-                  <br></br>
+                  ) : (
+                    <button onClick={onSignIn} className="inline-flex w-56 hover:bg-slate-300">
+                      Sign In
+                    </button>
+                  )}
+                </Menu.Item>
                   <Menu.Item>
                     <button onClick={toggleTheme} className="inline-flex w-56 hover:bg-slate-300">
                       Toggle Theme

--- a/src/app/components/QueryContainer.tsx
+++ b/src/app/components/QueryContainer.tsx
@@ -11,7 +11,8 @@ export default function QueryContainer({ endpoint, clickField }: any) { // TODO:
     setData(childData);
   };
   return (
-    <div className="ml-6 dark:bg-slate-800">
+    //matt added mt-10 for the margin top to help with the query container from signing in vs signing out
+    <div className="ml-6 dark:bg-slate-800 mt-10">
       <QueryGenerator childToParent={childToParent} clickField={clickField}/>
       <QueryResult data={data} endpoint={endpoint} />
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,7 +22,7 @@ export default function Home({ session }: any) {
           <div className="col-span-2 dark:bg-slate-800">
             <DisplayData data={data} setClickField={setClickField} />
           </div>
-          <div className="dark:bg-slate-800">
+          <div className="h-screen dark:bg-slate-800">
             <QueryContainer endpoint={data.endpoint} clickField={clickField} />
           </div>
         </div>


### PR DESCRIPTION
## Overview

**Issue Type**

- [ ] Bug
- [x] Feature
- [ ] Tech Debt

**Description**
This PR will allow users to sign in and sign out dynamically within the UI. For an unauthenticated user, the drop down should display `sign in`. For a user who is authenticated, we should display a `sign out` option. If the user is using oAuth from Google or Github. We will also grab their profile photo and display that on the front end. 

[**Ticket Item**](https://trello.com/c/iyNzQlb4/42-sign-in-and-sign-out-buttons-should-render-depending-on-user-status-add-functionality-to-display-avatar-icon-when-signed-in)




**Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix**

1. Go to the nav bar as an unauthenticated user and choose the sign in option.
2. For this case, use one of the oAuth examples
3. You should see your profile photo and the sign in option should say `sign out`
4. If you are not signed in. Selecting the drop down menu should display a `sign in` option.

**Previous behavior**
Before, the drop down menu was displaying both `sign in` and `sign out` options. As well as no profile was being displayed if you chose oAuth as a sign in option.

**Expected behavior**
Sign in and sign out will be dynamic depending on your authentication status. Using oAuth will also grab your profile photo and display it on the UI.
