### PR TITLE
nodes are rendering again

### DIFF
--- a/src/app/components/DisplayData.tsx
+++ b/src/app/components/DisplayData.tsx
@@ -91,11 +91,11 @@ export function DisplayData(props: any) { // TODO: type
   const schemaFields = schema.fields
   // let nodeState = [...initialNodes];
   let numOfNodes = 0;
-  initialNodes.length === 3 && schemaFields.map((fieldName, i) => {
+  initialNodes.length === 3 && schemaFields.map((field, i) => {
     let newNode: NodeObj = { 
-      id: fieldName,
+      id: field.name,
       position: { x: xIndexForFields, y: yIndexForFields }, 
-      data: { label: fieldName }, 
+      data: { label: field.name }, 
     };
     // push them to the initial nodes array (is it better to use a hook)
     initialNodes.push(newNode);
@@ -106,7 +106,7 @@ export function DisplayData(props: any) { // TODO: type
     xIndexForFields += 50
 
     // create a new edge to connect each type to the root query
-    const newEdgeForFields = { source: 'fields', target: fieldName};
+    const newEdgeForFields = { source: 'fields', target: field.name};
 
     // push the edges to the initial edges array (is it better to use a hook here?)
     initialEdges.push(newEdgeForFields);

--- a/src/app/components/EndpointForm.tsx
+++ b/src/app/components/EndpointForm.tsx
@@ -51,6 +51,7 @@ const onSignOut = () => {
     if (typeof endpoint === "string") {
       schemaAndEndpoint.endpoint = endpoint!;
     }
+    console.log("schema endpoint:", schemaAndEndpoint);
     childToParent(schemaAndEndpoint);
   };
   const { data: session, status } = useSession();


### PR DESCRIPTION
## Overview

**diagram-refactor*

- [ ] Bug
- [ ] Feature
- [x] Tech Debt

**Description**
After refactoring the introspection query so it returns requirements in terms of which fields require arguments to be queried, the diagram was not rendering, this PR solves that by refactoring how DisplayData renders the nodes based on these changes so the team can continue working on other features.

**[Trello link](https://trello.com/c/MGpIIkQi)**

**Steps to Confirm Tech Debt Fix**

1. Navigate to the home page
2. Enter a valid schema endpoint and submit
3. Diagram should contain fields, types and edges as before
