### PR TITLE
adds required arguments array to introsp query

### DIFF
--- a/src/utils/getSchema.ts
+++ b/src/utils/getSchema.ts
@@ -37,7 +37,7 @@ export async function getSchema(data: FormData) {
     throw new Error('Invalid endpoint');
   }
   const schema = await schemaConnect(endpoint);
-  console.log('this is the schema', schema);
+  console.log('this is the schema', JSON.stringify(schema));
   let err = false;
   if(Object.keys(schema).length === 0) err = true;
   


### PR DESCRIPTION
## Overview

**adds required arguments array to introsp query**

- [ ] Bug
- [x] Feature
- [ ] Tech Debt

**Description**
Object returned by schemaConnect now includes a new array for each field, including all required arguments to query that field

**Steps to Validate Feature**

1. Navigate to the home page
2. Enter a valid schema endpoint and submit
3. Object returned by schemaConnect should be logged in the terminal with the added array of required arguments for each field
