### PR TITLE
Reset Button

### DIFF
--- a/src/app/components/DisplayData.tsx
+++ b/src/app/components/DisplayData.tsx
@@ -20,6 +20,7 @@ import ReactFlow, {
 
 import 'reactflow/dist/style.css';
 import { CircularProgress } from "@mui/material";
+import { data } from "autoprefixer";
 
 const initialNodes: Node[] = [ 
   { id: 'query', position: { x: 500, y: 0 }, data: { label: 'Root Query' } },
@@ -151,12 +152,29 @@ export function DisplayData(props: Props) { // TODO: type
     // setNodes(nodeState)
   }}
 
+  const handleClick = () => {
+    props.setData({schema:{fields: [], types: {}}, endpoint:""})
+    const userInputtedEndpoint = document.getElementById('simple-search') as HTMLInputElement
+    userInputtedEndpoint.value = ""
+  }
+
 
   // fit view on load
   // const onLoad= (instance:any) => setTimeout(() => instance.fitView(), 0);
 
   return (
+    
        <div className="ml-4">
+                {/* Reset Button */}
+                <button
+                     className="ml-1 bg-blue-500 dark:bg-slate-500 text-white px-3 py-1 rounded-xl my-1 inline-flex dark:border dark:border-white dark:hover:bg-slate-300 dark:hover:text-slate-900"
+                     onClick={() => {
+                       handleClick();
+                     }}
+                   >
+                     Reset
+                     <svg aria-hidden="true" className="w-5 h-5 ml-2 -mr-1" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z" clip-rule="evenodd"></path></svg>
+                   </button>
               {/* <div key={index}>
                 <h3>{type}:</h3> */}
               <Suspense fallback={<CircularProgress />}>
@@ -183,5 +201,6 @@ export function DisplayData(props: Props) { // TODO: type
                 </ul>
               </Suspense>
               </div> 
+
   );
               }

--- a/src/app/components/EndpointForm.tsx
+++ b/src/app/components/EndpointForm.tsx
@@ -121,6 +121,7 @@ const onSignOut = () => {
             ></path>
           </svg>
         </button>
+
         {/* User Account Dropdown */}
         <div className="flex items-center space-x-1.5">
           <Menu as='div' className='relative inline-block text-left'>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,7 +34,7 @@ export default function Home({ session }: any) {
         <EndpointForm childToParent={childToParent} />
         <div className="grid grid-cols-3">
           <div className="col-span-2 dark:bg-slate-800">
-            {data.schema.fields.length && <DisplayData data={data} setClickField={setClickField} />}
+            {data.schema.fields.length && <DisplayData data={data} setClickField={setClickField} setData={setData} />}
           </div>
           <div className="h-screen dark:bg-slate-800">
             <QueryContainer endpoint={data.endpoint} clickField={clickField} setIsSaveModalOpen={setIsSaveModalOpen} queryAsString={queryAsString} setQueryAsString={setQueryAsString} />

--- a/types.ts
+++ b/types.ts
@@ -3,6 +3,7 @@ import {Dispatch, SetStateAction} from "react"
 export type Props = {
     data: Data,
     setClickField: Dispatch<SetStateAction<{type: string, field: string}>>
+    setData: Dispatch<SetStateAction<Data>>
   }
 
 export type SchemaData = {


### PR DESCRIPTION
## Overview

**Issue Type**

- [ ] Bug
- [x] Feature
- [ ] Tech Debt

**Description**
Reset button feature implemented to allow user to reset the React Flow diagram which also clears the input field.

**Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix**

1. Run the dev server and open localhost:3000
2. Input a valid GraphQL Endpoint
3. Reset button should appear, clicking it should dynamically clear the input field and the React Flow.
4. Input a different valid GraphQL Endpoint and see the different nodes and edges.

**Previous behavior**
No reset button implemented, user had to refresh the page to enter a different endpoint.

