### PR TITLE
queries can now be saved in DB with a reference to the correct user

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -2,12 +2,11 @@ import NextAuth from "next-auth"
 import GithubProvider from "next-auth/providers/github"
 import GoogleProvider from "next-auth/providers/google";
 import CredentialsProvider from "next-auth/providers/credentials";
+import { QueryResult } from "pg";
 import { db } from '../../../../utils/database';
 const bcrypt = require('bcrypt');
-
 // resource: https://www.youtube.com/watch?v=A5ZN--P9vXM&pp=ygUObmV4dGF1dGggb2F1dGg%3D
 const handler = NextAuth({
-
     // providers array allows nextauth to handle oauth; just need ot import the providers
     providers: [
         CredentialsProvider({
@@ -23,24 +22,24 @@ const handler = NextAuth({
                 try{
                     // look up user
                     const query: string = 'SELECT * FROM users WHERE username=$1;'
-                    const user: any = await db.query(query, [credentials?.username]); // TODO: type
+                    const user: QueryResult<any> = await db.query(query, [credentials?.username]); // TODO: type
                     // throw error if user does not exist in db
                     if(!user.rows[0]) {
                         throw new Error('username/password is incorrect');
                     }
                     // compare provided password to hash stored in db
-                    const match = await bcrypt.compare(credentials?.password, user.rows[0].password);
+                    const match: boolean = await bcrypt.compare(credentials?.password, user.rows[0].password);
                     if(match) {
-                        // any object returned will be saved in user property of JWT 
-                        return user;
+                        // any object returned will be saved in user property of JWT
+                        const userData = { userId: user.rows[0]._id, email: user.rows[0].username };
+                        return userData;
                     } else {
                         // returning null results in an error being displayed that advises user to check their details
                         return null;
-                    }    
+                    }
                 } catch(error) {
                     console.log('error with credential authentication: ', error);
                 }
-    
             }
         }),
         GithubProvider({
@@ -51,12 +50,8 @@ const handler = NextAuth({
             clientId: process.env.GOOGLE_CLIENT_ID,
             clientSecret: process.env.GOOGLE_CLIENT_SECRET
         }),
-
     ],
     // unsure of why we need this currently.
     secret: process.env.JWT_SECRET
-
-    
 })
-
 export {handler as GET, handler as POST}

--- a/src/app/api/queries/route.ts
+++ b/src/app/api/queries/route.ts
@@ -1,26 +1,39 @@
 import { db } from "@/utils/database"
-
+import { create } from "@mui/material/styles/createTransitions";
 type queryData = {
     queryName: string,
     queryText: string,
     endpoint: string,
+    userEmail: string
 }
-
 export async function POST(request: Request) {
+    const body: queryData = await request.json();
+    const { queryName, queryText, endpoint, userEmail } = body;
+    const findUserStr: string = `
+        SELECT *
+        FROM users
+        WHERE username=$1;
+        `;
+        const createUserStr: string = `
+        INSERT INTO users (username, password)
+        VALUES ($1, $2)
+        RETURNING *;
+        `;
+    const addQueryString: string = `
+        INSERT INTO queries (query_name, query_text, endpoint, user_id)
+        VALUES ($1, $2, $3, $4)
+        RETURNING *;
+        `;
     try{
-        const body: queryData = await request.json();
-        const { queryName, queryText, endpoint } = body;
-
-        const addQueryString: string = 'INSERT INTO queries (query_name, query_text, endpoint, user_id) VALUES ($1, $2, $3, $4)'
-        const response: any = await db.query(addQueryString, [queryName, queryText, endpoint, 1]);
-
+        let userResponse = await db.query(findUserStr, [userEmail]);
+        if(!userResponse.rows[0]) userResponse = await db.query(createUserStr, [userEmail, 'XXXX']);
+        const userId = userResponse.rows[0]._id;
+        console.log('THIS SHOULD BE THE USERID => ', userId);
+        const response: any = await db.query(addQueryString, [queryName, queryText, endpoint, userId]);
         console.log('response from adding query to queries table => ', response);
         return new Response(response.json());
-
     } catch(err: any) { // TODO: Type
         console.log(err);
-
         return new Response(err.message)
     }
-
 }

--- a/src/app/components/SaveModal.tsx
+++ b/src/app/components/SaveModal.tsx
@@ -1,27 +1,28 @@
 import React, { ChangeEvent, MouseEvent, FormEvent, useState } from "react";
+import { useSession } from "next-auth/react";
 import { Dialog } from '@headlessui/react';
 import { SaveModalProps } from "../../../types";
-
 export default function SaveModal(props: SaveModalProps) {
-    const { isSaveModalOpen, 
-            setIsSaveModalOpen, 
-            setIsSaveResponseModalOpen, 
-            setSaveResponseStatus, 
-            query, 
-            endpoint, 
+    const { isSaveModalOpen,
+            setIsSaveModalOpen,
+            setIsSaveResponseModalOpen,
+            setSaveResponseStatus,
+            query,
+            endpoint,
         } = props;
-
     const [queryName, setQueryName] = useState('');
-
+    const { data: instance } = useSession();
+    console.log('this is the session from within the savemodal => ', instance);
+    const userEmail: string | undefined | null = instance?.user.email;
     async function handleSaveQuery(e: FormEvent) {
         e.preventDefault();
-
         const queryData = {
             queryName,
             queryText: query,
             endpoint,
+            userEmail
         }
-        const res = await fetch('http://localhost:3000/api/queries', {
+        const res = await fetch('/api/queries', {
             method: "POST",
             mode: "cors",
             credentials: "same-origin",
@@ -31,7 +32,6 @@ export default function SaveModal(props: SaveModalProps) {
             body: JSON.stringify(queryData)
         })
         console.log('this is the response from posting query to DB => ', res);
-
         // const responseMessage = (res.ok) ? 'Query Saved Succesfully!' : 'Something Went Wrong'
         setSaveResponseStatus(res.ok);
         setIsSaveModalOpen(false);


### PR DESCRIPTION
**Issue Type**

- [ ] Bug
- [x] Feature
- [ ] Tech Debt

**Description**
When saving queries, they are now stored in the database with a reference to the appropriate user, so they can be properly retrieved later. 

**Ticket Item**
54
[Trello link](https://trello.com/c/pDAQ7FzO/54-postgresql-adapter)


**Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix**

1. Sign into an account with either OAuth or user credentials
2. Click on the "Save Query" button
3. Enter a name for the query in the first input field
4. Click on "Save" button
5. In postgres database, execute query "SELECT * FROM queries;"
6. View most recent saved query, and take note of user_id field
7. Execute "SELECT * FROM users;" and confirm the user_id associated with the query corresponds to the correct user 

**Previous behavior**
Previously, queries were stored without referencing a specific user. 

**Expected behavior**
When users save queries, the queries will now be stored with a reference to the user_id of the user, so that they can be properly referenced later. 
